### PR TITLE
fix README typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Use cases
 1) Create a temporary container for testing purposes:
 
 ```bash
-  docker run --rm fauria/vsftp
+  docker run --rm fauria/vsftpd
 ```
 
 2) Create a container in active mode using the default user account, with a binded data directory:


### PR DESCRIPTION
It seems to be a wrong argument.

```
$ docker run --rm fauria/vsftp
Unable to find image 'fauria/vsftp:latest' locally
Pulling repository docker.io/fauria/vsftp
docker: Error: image fauria/vsftp:latest not found.
See 'docker run --help'.
```

But I succeeded to execute the command below.

```
$ docker run --rm fauria/vsftpd
/usr/sbin/run-vsftpd.sh: line 27: /sbin/ip: No such file or directory
	*************************************************
	*                                               *
	*    Docker image: fauria/vsftd                 *
	*    https://github.com/fauria/docker-vsftpd    *
	*                                               *
	*************************************************

	SERVER SETTINGS
	---------------
	· FTP User: admin
	· FTP Password: ***************
	· Log file: /var/log/vsftpd/vsftpd.log
	· Redirect vsftpd log to STDOUT: No.
```