### PR TITLE
Fix xferlog output filename

### DIFF
--- a/vsftpd.conf
+++ b/vsftpd.conf
@@ -38,6 +38,7 @@ hide_ids=YES
 
 ## Enable logging
 xferlog_enable=YES
+xferlog_std_format=YES
 xferlog_file=/var/log/vsftpd/vsftpd.log
 
 ## Enable active mode


### PR DESCRIPTION
Add `xferlog_std_format=YES` to vsftpd.conf. 

Otherwise, xferlog_file is not taken into account, as specified by the doc cf. http://manpages.ubuntu.com/manpages/bionic/en/man5/vsftpd.conf.5.html

```
       xferlog_file
              This option is the name of the file to which we write the  wu-ftpd  style  transfer
              log.  The  transfer  log is only written if the option xferlog_enable is set, along
              with xferlog_std_format.  Alternatively, it is written if you have set  the  option
              dual_log_enable.

              Default: /var/log/xferlog
```