### PR TITLE
Enhance vsftpd configs.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ LABEL Description="vsftpd Docker image based on Centos 7. Supports passive mode 
 RUN yum -y update && yum clean all
 RUN yum install -y \
 	vsftpd \
+        iproute \
 	db4-utils \
 	db4 && yum clean all
 
@@ -20,6 +21,7 @@ RUN groupmod -g ${GROUP_ID} ftp
 
 ENV FTP_USER **String**
 ENV FTP_PASS **Random**
+ENV REVERSE_LOOKUP_ENABLE YES
 ENV PASV_ADDRESS **IPv4**
 ENV PASV_ADDR_RESOLVE NO
 ENV PASV_ENABLE YES

--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ This image uses environment variables to allow the configuration of some paramet
 
 ----
 
+* Variable name: `REVERSE_LOOKUP_ENABLE`
+* Default value: YES.
+* Accepted values: YES or NO.
+* Description: Set to YES if you want vsftpd to transform the ip address into the hostname, before pam authentication. This is useful if you use pam_access including the hostname. If you want vsftpd to run on the environment where the reverse lookup for some hostname is available and the name server doesn't respond for a while, you should set this to NO to avoid a performance issue.
+
+----
+
 * Variable name: `PASV_ADDRESS_ENABLE`
 * Default value: NO
 * Accepted values: <NO|YES>

--- a/run-vsftpd.sh
+++ b/run-vsftpd.sh
@@ -29,14 +29,17 @@ if [ "$PASV_ADDRESS" = "**IPv4**" ]; then
     export PASV_ADDRESS=$(/sbin/ip route|awk '/default/ { print $3 }')
 fi
 
-echo "pasv_address=${PASV_ADDRESS}" >> /etc/vsftpd/vsftpd.conf
-echo "pasv_max_port=${PASV_MAX_PORT}" >> /etc/vsftpd/vsftpd.conf
-echo "pasv_min_port=${PASV_MIN_PORT}" >> /etc/vsftpd/vsftpd.conf
-echo "pasv_addr_resolve=${PASV_ADDR_RESOLVE}" >> /etc/vsftpd/vsftpd.conf
-echo "pasv_enable=${PASV_ENABLE}" >> /etc/vsftpd/vsftpd.conf
-echo "file_open_mode=${FILE_OPEN_MODE}" >> /etc/vsftpd/vsftpd.conf
-echo "local_umask=${LOCAL_UMASK}" >> /etc/vsftpd/vsftpd.conf
-echo "xferlog_std_format=${XFERLOG_STD_FORMAT}" >> /etc/vsftpd/vsftpd.conf
+# Custom exposed options:
+vsftpd_conf=/etc/vsftpd/vsftpd.conf
+grep -Fq "reverse_lookup_enable=" ${vsftpd_conf} || echo "reverse_lookup_enable=${REVERSE_LOOKUP_ENABLE}" >> ${vsftpd_conf}
+grep -Fq "pasv_address="          ${vsftpd_conf} || echo "pasv_address=${PASV_ADDRESS}"                   >> ${vsftpd_conf}
+grep -Fq "pasv_max_port="         ${vsftpd_conf} || echo "pasv_max_port=${PASV_MAX_PORT}"                 >> ${vsftpd_conf}
+grep -Fq "pasv_min_port="         ${vsftpd_conf} || echo "pasv_min_port=${PASV_MIN_PORT}"                 >> ${vsftpd_conf}
+grep -Fq "pasv_addr_resolve="     ${vsftpd_conf} || echo "pasv_addr_resolve=${PASV_ADDR_RESOLVE}"         >> ${vsftpd_conf}
+grep -Fq "pasv_enable="           ${vsftpd_conf} || echo "pasv_enable=${PASV_ENABLE}"                     >> ${vsftpd_conf}
+grep -Fq "file_open_mode="        ${vsftpd_conf} || echo "file_open_mode=${FILE_OPEN_MODE}"               >> ${vsftpd_conf}
+grep -Fq "local_umask="           ${vsftpd_conf} || echo "local_umask=${LOCAL_UMASK}"                     >> ${vsftpd_conf}
+grep -Fq "xferlog_std_format="    ${vsftpd_conf} || echo "xferlog_std_format=${XFERLOG_STD_FORMAT}"       >> ${vsftpd_conf}
 
 # Get log file path
 export LOG_FILE=`grep xferlog_file /etc/vsftpd/vsftpd.conf|cut -d= -f2`


### PR DESCRIPTION

Env: CentOS Linux release 7.6.1810 (Core) / Docker version 18.09.6, build 481bc77156

During use this image, I have encountered two problems.

#### 1. vsftpd login is quite slow

After exposed external network access through router mapping, vsftpd login is quite slow, almost takes 10 seconds every time. I guess it should be a DNS related issue. Googled for a while, found this post [vsftpd log in is slow](http://geekinlinux.blogspot.com/2012/11/vsftpd-log-in-is-slow.html)，solved this problem. Don't understand what's deep inside.

#### 2. Duplicate echo operation in `run-vsftpd.sh` seems unnecessary while restart contanier.

These lines are:

    echo "pasv_address=${PASV_ADDRESS}" >> /etc/vsftpd/vsftpd.conf
    echo "pasv_max_port=${PASV_MAX_PORT}" >> /etc/vsftpd/vsftpd.conf
    echo "pasv_min_port=${PASV_MIN_PORT}" >> /etc/vsftpd/vsftpd.conf
    echo "pasv_addr_resolve=${PASV_ADDR_RESOLVE}" >> /etc/vsftpd/vsftpd.conf
    echo "pasv_enable=${PASV_ENABLE}" >> /etc/vsftpd/vsftpd.conf
    echo "file_open_mode=${FILE_OPEN_MODE}" >> /etc/vsftpd/vsftpd.conf
    echo "local_umask=${LOCAL_UMASK}" >> /etc/vsftpd/vsftpd.conf
    echo "xferlog_std_format=${XFERLOG_STD_FORMAT}" >> /etc/vsftpd/vsftpd.conf

And because of these `echo`s, manual modification of these options in `vsftpd.conf` will be overrided while restart.

#### This pull request.

I forked and made a pull request, hope it's useful.

CHANGES:

 1. Add ENV `REVERSE_LOOKUP_ENABLE`;
 2. Add checks before `echo` operations;
 3. Add `iproute` package in order to use `/sbin/ip route`?
