### PR TITLE
Install iproute package to provide missing ip command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,8 @@ RUN yum -y update && yum clean all
 RUN yum install -y \
 	vsftpd \
 	db4-utils \
-	db4 && yum clean all
+	db4 \
+	iproute && yum clean all
 
 RUN usermod -u ${USER_ID} ftp
 RUN groupmod -g ${GROUP_ID} ftp


### PR DESCRIPTION
The vsfptd `pasv_address` configuration setting is empty when not providing an ip address.

When not providing the environment variable `PASV_ADDRESS` it defaults to `**IPv4**`. During startup the `run-vstfpd.sh` command will check if `PASV_ADDRESS` equals `**IPv4**` and if so, it will try to determine the containers ip address using the `/sbin/ip` command.

The current `centos:7` image is missing the `/sbin/ip` command, which causes the `PASV_ADDRESS` environment variable to become empty. The solution is to install the `iproute` package, which will provide the missing `/sbin/ip` command.
