### PR TITLE
Removed misleading typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Exposed ports and volumes
 
 The image exposes ports `20` and `21`. Also, exports two volumes: `/home/vsftpd`, which contains users home directories, and `/var/log/vsftpd`, used to store logs.
 
-When sharing a homes directory between the host and the container (`/home/vsftpd`) the owner user id and group id should be 14 and 80 respectively. This corresponds to ftp user and ftp group on the container, but may match something else on the host.
+When sharing a homes directory between the host and the container (`/home/vsftpd`) the owner user id and group id should be 14 and 50 respectively. This corresponds to ftp user and ftp group on the container, but may match something else on the host.
 
 Use cases
 ----


### PR DESCRIPTION
GID for vsftpd is 50, not 80