### PR TITLE
FTP_USER entry now appended to virtual_users.txt instead of overwriting the whole file

### DIFF
--- a/run-vsftpd.sh
+++ b/run-vsftpd.sh
@@ -21,7 +21,10 @@ fi
 mkdir -p "/home/vsftpd/${FTP_USER}"
 chown -R ftp:ftp /home/vsftpd/
 
-echo -e "${FTP_USER}\n${FTP_PASS}" > /etc/vsftpd/virtual_users.txt
+if ! grep -Fxq "${FTP_USER}" /etc/vsftpd/virtual_users.txt
+then
+    echo -e "${FTP_USER}\n${FTP_PASS}" >> /etc/vsftpd/virtual_users.txt
+fi
 /usr/bin/db_load -T -t hash -f /etc/vsftpd/virtual_users.txt /etc/vsftpd/virtual_users.db
 
 # Set passive mode parameters:


### PR DESCRIPTION
Check the virtual_users.txt file for FTP_USER entry first, to see if the entry already exists. If the user already exists, it won't be appended to the file. Using ">>" instead of ">" stream which will overwrite the file.