### PR TITLE
Added support for a new env variable that sets the listen port

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,12 @@ This image uses environment variables to allow the configuration of some paramet
 * Description: Set to YES if you want to disable the PORT security check that ensures that outgoing data connections can only connect to the client. Only enable if you know what you are doing! Legitimate use for this is to facilitate FXP support.
 
 ----
+* Variable name: `LISTEN_PORT`
+* Default value: 21
+* Accepted values: Any valid port number.
+* Description: Set to a port above 1024 if you are using podman in rootless mode.
+
+----
 
 Exposed ports and volumes
 ----

--- a/run-vsftpd.sh
+++ b/run-vsftpd.sh
@@ -40,6 +40,7 @@ echo "xferlog_std_format=${XFERLOG_STD_FORMAT}" >> /etc/vsftpd/vsftpd.conf
 echo "reverse_lookup_enable=${REVERSE_LOOKUP_ENABLE}" >> /etc/vsftpd/vsftpd.conf
 echo "pasv_promiscuous=${PASV_PROMISCUOUS}" >> /etc/vsftpd/vsftpd.conf
 echo "port_promiscuous=${PORT_PROMISCUOUS}" >> /etc/vsftpd/vsftpd.conf
+echo "listen_port=${LISTEN_PORT}" >> /etc/vsftpd/vsftpd.conf
 
 # Get log file path
 export LOG_FILE=`grep xferlog_file /etc/vsftpd/vsftpd.conf|cut -d= -f2`


### PR DESCRIPTION
This will enable vsftpd to set listen port higher than 1024 if required so that we can run the container using podman in rootless mode.